### PR TITLE
fix: rust install command on mac

### DIFF
--- a/helpers/check-shuttle.ts
+++ b/helpers/check-shuttle.ts
@@ -101,9 +101,13 @@ function findCargoBinDir(): string {
 export function installRust() {
     switch (process.platform) {
         case "linux":
-        case "darwin":
             execSync(
                 `curl --proto '=https' --tlsv1.3 https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain ${RUSTC_VERSION}`
+            )
+            break
+        case "darwin":
+            execSync(
+                `curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain ${RUSTC_VERSION}`
             )
             break
         case "win32":

--- a/helpers/package.ts
+++ b/helpers/package.ts
@@ -18,7 +18,7 @@ export function patchPackage(projectPath: string) {
     packages["scripts"]["start"] =
         "cargo shuttle project new --working-directory ./backend/"
     packages["scripts"]["deploy"] =
-        "npm run build && cargo shuttle deploy --working-directory ./backend/"
+        "npm run build && cargo shuttle deploy --working-directory ./backend/ --allow-dirty"
     packages["scripts"]["dev"] =
         'npm run build && concurrently --names "next, shuttle" --kill-others "next dev" "cargo shuttle run --working-directory ./backend/"'
     packages["scripts"]["stop"] =


### PR DESCRIPTION
The rust install curl command did not work on our mac VM since it did not support tlsv1.3. I'm not sure if this is common for macs, but using 1.2 should work for mac users with 1.3 installed as well. Is this something we should consider for the other platforms as well?

Also added the "--allow-dirty" flag to deploy, as it could be awkward for users to have to change the script/run the command themselves.