### PR TITLE
Feat/nuxt support

### DIFF
--- a/helpers/constants.ts
+++ b/helpers/constants.ts
@@ -17,4 +17,4 @@ export const SHUTTLE_SAAS_URL =
     "https://github.com/shuttle-hq/shuttle-examples/fullstack-templates/saas"
 
 export const SHUTTLE_SAAS_NUXT_URL =
-"https://github.com/shuttle-hq/shuttle-examples/fullstack-templates/saas-nuxt"
+"https://github.com/shuttle-hq/shuttle-examples-1/fullstack-templates/saas-nuxt"

--- a/helpers/constants.ts
+++ b/helpers/constants.ts
@@ -15,3 +15,6 @@ export const SHUTTLE_EXAMPLE_URL =
 
 export const SHUTTLE_SAAS_URL =
     "https://github.com/shuttle-hq/shuttle-examples/fullstack-templates/saas"
+
+export const SHUTTLE_SAAS_NUXT_URL =
+"https://github.com/shuttle-hq/shuttle-examples/fullstack-templates/saas-nuxt"

--- a/helpers/package.ts
+++ b/helpers/package.ts
@@ -129,49 +129,21 @@ module.exports = nextConfig
     }
 }
 
+// Just a very basic overwrite of the nuxt.config.ts file
 export function patchNuxtConfig(projectPath: string) {
     const configPath = path.join(projectPath, "nuxt.config.ts")
     console.log(configPath)
-    if (existsSync(configPath)) {
-        const source = ts.createSourceFile(
-            "nuxt.config.ts",
-            readFileSync(configPath).toString(),
-            ts.ScriptTarget.ES5
-        )
-        // stringify source
-        
-        const stringifiedSource = JSON.stringify(source)
-        
-        //const result = ts.transform(source, [transformer])
-        //const newSource = ts.createPrinter().printFile(result.transformed[0])
-        writeFileSync(
-            configPath,
-            `
+    writeFileSync(
+        configPath,
+        `
 export default defineNuxtConfig({
-    nitro: {
-        prerender: {
-        crawlLinks: true
-        }
-    },
-})
-`       )
-    } else {
-        writeFileSync(
-            configPath,
-            `
-export default defineNuxtConfig({
-    nitro: {
-        prerender: {
-        crawlLinks: true
-        }
-    },
-    generate: {
-        dir: './backend/static'
-      }
-})
-`
-        )
+  nitro: {
+    prerender: {
+      crawlLinks: true
     }
+  }
+})
+`)
 }
 
 

--- a/helpers/package.ts
+++ b/helpers/package.ts
@@ -47,7 +47,7 @@ export function patchNuxtPackage(projectPath: string) {
     const packages = JSON.parse(data.toString())
     
     packages["scripts"]["build"] =
-        "npx nuxi generate && cargo build --manifest-path ./backend/Cargo.toml"
+        "npx nuxi generate && cp -R ./.output/public ./backend/static && cargo build --manifest-path ./backend/Cargo.toml"
     packages["scripts"]["shuttle-login"] =
         "cargo shuttle login --working-directory ./backend/"
     packages["scripts"]["start"] =

--- a/index.ts
+++ b/index.ts
@@ -160,6 +160,14 @@ async function run(): Promise<void> {
             }
         }
     }
+    
+    const VALID_FULLSTACK_OPTIONS = ['saas']; 
+    
+    if (program.fullstackExample && !VALID_FULLSTACK_OPTIONS.includes(program.fullstackExample)) {
+        throw {
+            error: `Invalid fullstack example type. Valid options are: ${VALID_FULLSTACK_OPTIONS.join(', ')}`,
+        }
+    }
 
     if (!projectPath) {
         const res = await prompts({
@@ -211,7 +219,6 @@ async function run(): Promise<void> {
             repository: SHUTTLE_SAAS_URL,
             projectPath: resolvedProjectPath,
         })
-
         createShuttleToml(shuttleProjectName, resolvedProjectPath)
         fullstackExample = true
     } else if (!fullstackExample) {

--- a/index.ts
+++ b/index.ts
@@ -162,7 +162,7 @@ async function run(): Promise<void> {
         }
     }
     
-    const VALID_FULLSTACK_OPTIONS = ['saas']; 
+    const VALID_FULLSTACK_OPTIONS = ['saas', 'saas-nuxt']; 
     
     if (program.fullstackExample && !VALID_FULLSTACK_OPTIONS.includes(program.fullstackExample)) {
         throw {

--- a/index.ts
+++ b/index.ts
@@ -26,6 +26,7 @@ import {
     SHUTTLE_EXAMPLE_URL,
     SHUTTLE_SAAS_URL,
     PROTOC_VERSION,
+    SHUTTLE_SAAS_NUXT_URL,
 } from "./helpers/constants"
 
 let projectPath = ""
@@ -217,6 +218,13 @@ async function run(): Promise<void> {
     if (program.fullstackExample == "saas") {
         await cloneExample({
             repository: SHUTTLE_SAAS_URL,
+            projectPath: resolvedProjectPath,
+        })
+        createShuttleToml(shuttleProjectName, resolvedProjectPath)
+        fullstackExample = true
+    } else if (program.fullstackExample === "saas-nuxt") {
+        await cloneExample({
+            repository: SHUTTLE_SAAS_NUXT_URL,
             projectPath: resolvedProjectPath,
         })
         createShuttleToml(shuttleProjectName, resolvedProjectPath)

--- a/index.ts
+++ b/index.ts
@@ -206,7 +206,6 @@ async function run(): Promise<void> {
     }
     
     let fullstackExample = false
-/*
     if (program.fullstackExample == "saas") {
         await cloneExample({
             repository: SHUTTLE_SAAS_URL,
@@ -215,15 +214,7 @@ async function run(): Promise<void> {
 
         createShuttleToml(shuttleProjectName, resolvedProjectPath)
         fullstackExample = true
-    } else {
-        console.error(
-            "The provided fullstack example is not known. Please provide a supported example."
-        )
-        console.log("Currently supported examples: saas")
-        return
-    }
-    */
-    if (!fullstackExample) {
+    } else if (!fullstackExample) {
         const args = []
 
         if (program.javascript) {
@@ -284,7 +275,15 @@ async function run(): Promise<void> {
             patchPackage(resolvedProjectPath)
             patchNextConfig(resolvedProjectPath)
         }
+    } else {
+        console.error(
+            "The provided fullstack example is not known. Please provide a supported example."
+        )
+        console.log("Currently supported examples: saas")
+        return
     }
+    
+    
 
     const shuttleOrange = chalk.hex("#ff8a3f")
     console.log(

--- a/yarn.lock
+++ b/yarn.lock
@@ -49,7 +49,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
+"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -110,7 +110,7 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/parser@^5.0.0", "@typescript-eslint/parser@^5.50.0":
+"@typescript-eslint/parser@^5.50.0":
   version "5.52.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.52.0.tgz"
   integrity sha512-e2KiLQOZRo4Y0D/b+3y08i3jsekoSkOYStROYmPUnGMEoA0h+k2qOH5H6tcjIc68WDvGwH+PaOrP1XRzLJ6QlA==
@@ -188,7 +188,7 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.8.0:
+acorn@^8.8.0:
   version "8.8.2"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz"
   integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
@@ -262,14 +262,6 @@ callsites@^3.0.0:
   resolved "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
-chalk@^4.0.0:
-  version "4.1.2"
-  resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
-  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
-
 chalk@2.4.2:
   version "2.4.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz"
@@ -278,6 +270,14 @@ chalk@2.4.2:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
+
+chalk@^4.0.0:
+  version "4.1.2"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
 
 color-convert@^1.9.0:
   version "1.9.3"
@@ -293,15 +293,15 @@ color-convert@^2.0.1:
   dependencies:
     color-name "~1.1.4"
 
-color-name@~1.1.4:
-  version "1.1.4"
-  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
-  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 command-exists@^1.2.9:
   version "1.2.9"
@@ -411,7 +411,7 @@ eslint-visitor-keys@^3.3.0:
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz"
   integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
-eslint@*, "eslint@^6.0.0 || ^7.0.0 || ^8.0.0", eslint@^8.33.0, eslint@>=5, eslint@>=7.0.0:
+eslint@^8.33.0:
   version "8.34.0"
   resolved "https://registry.npmjs.org/eslint/-/eslint-8.34.0.tgz"
   integrity sha512-1Z8iFsucw+7kSqXNZVslXS8Ioa4u2KM7GPwuKtkTFAqZ/cHMcEaR+1+Br0wLlot49cNxIiZk5wp8EAbPcYZxTg==
@@ -484,12 +484,7 @@ estraverse@^4.1.1:
   resolved "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
-estraverse@^5.1.0:
-  version "5.3.0"
-  resolved "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz"
-  integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
-
-estraverse@^5.2.0:
+estraverse@^5.1.0, estraverse@^5.2.0:
   version "5.3.0"
   resolved "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
@@ -1021,7 +1016,7 @@ type-fest@^0.20.2:
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
-typescript@^4.9.5, "typescript@>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta":
+typescript@^4.9.5:
   version "4.9.5"
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==


### PR DESCRIPTION
This adds basic support for a Nuxt app instead of Next.js by using the `--nuxt` argument.

It also brings a fix to the CLI flow, currently if using anything but `--fullstack-example xxx` it will not work properly. (It also currently doesnt check if the xxx after fullstack exists).

Something that was blocking nuxt integration as if I just proivded the `--nuxt` argument it would fail because it was missing `saas`.

Now, it checks if an existing argument/template (saas) has been entered when using `--fullstack-example`.And throws and error if not.
But now it also works if using `--nuxt`, `--ts`, `--js`, etc.

Nuxt-SaaS Example:
https://nuxt-saas11.shuttleapp.rs/

PR: https://github.com/shuttle-hq/shuttle-examples-1/pull/1