### PR TITLE
chore: remove protoc, bump shuttle version

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,5 +77,5 @@ this.
 If you want to install dependencies for `create-shuttle-app` manually, these are the required 
 native dependencies:
 
-- Rust version 1.65: https://www.rust-lang.org/tools/install
+- Rust version 1.68: https://www.rust-lang.org/tools/install
 - cargo-shuttle latest version: https://docs.shuttle.rs/introduction/installation

--- a/helpers/check-shuttle.ts
+++ b/helpers/check-shuttle.ts
@@ -31,14 +31,6 @@ export function checkInstalled(dependency: string, semver: string): boolean {
         .toString()
         .split(" ")[1]
 
-    // Hacky weekend fix for cases where `protoc --version` returns "libprotoc 22.2" (missing major version)
-    if (
-        dependency === "protoc" &&
-        (installedVersion.match(/\./g) || []).length !== 2
-    ) {
-        installedVersion = "3." + installedVersion
-    }
-
     return satisfies(installedVersion, semver)
 }
 
@@ -179,62 +171,3 @@ export function installRust() {
     }
 }
 
-/**
- * Installs protoc.
- * @throws Will throw an error if the users platform is not mac or linux,
- * or if their cpu arch is not x86_64 or arm64.
- */
-export function installProtoc() {
-    let arch: string
-
-    switch (os.arch()) {
-        case "arm64":
-            arch = "aarch_64"
-            break
-        case "x64":
-            arch = "x86_64"
-            break
-        default:
-            throw {
-                error: `create-shuttle-app can't install Protoc
-                    on: ${chalk.red(os.arch())} \n
-                    Refer to "https://grpc.io/docs/protoc-installation/#install-pre-compiled-binaries-any-os" 
-                    for instructions on installing protoc for your operating system.`,
-            }
-    }
-
-    switch (process.platform) {
-        case "linux":
-            execSync(
-                `curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v21.9/protoc-21.9-linux-${arch}.zip &&\
-                    sudo unzip -o protoc-21.9-linux-${arch}.zip -d /usr/local bin/protoc &&\
-                    sudo unzip -o protoc-21.9-linux-${arch}.zip -d /usr/local 'include/*' &&\
-                    rm -f protoc-21.9-linux-${arch}.zip`
-            )
-            break
-        case "darwin":
-            execSync(
-                `curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v21.9/protoc-21.9-osx-${arch}.zip &&\
-                    sudo unzip -o protoc-21.9-osx-${arch}.zip -d /usr/local bin/protoc &&\
-                    sudo unzip -o protoc-21.9-osx-${arch}.zip -d /usr/local 'include/*' &&\
-                    rm -f protoc-21.9-osx-${arch}.zip`
-            )
-            break
-        case "win32":
-            throw {
-                error: `create-shuttle-app can't install Protoc automatically 
-                    on: ${chalk.red("Windows")} \n
-                    Please refer to our install instructions
-                    for Windows here: https://docs.shuttle.rs/support/installing-protoc#windows.
-                    After installing protoc, please run create-shuttle-app again.`,
-            }
-        default:
-            throw {
-                error: `create-shuttle-app can't install Protoc automatically 
-                    on: ${chalk.red(process.platform)} \n
-                    Refer to "https://grpc.io/docs/protoc-installation/#install-pre-compiled-binaries-any-os" 
-                    for instructions on installing protoc for your operating system.
-                    After installing protoc, please run create-shuttle-app again`,
-            }
-    }
-}

--- a/helpers/constants.ts
+++ b/helpers/constants.ts
@@ -1,7 +1,6 @@
 // The minimum required version of rust.
 export const RUSTC_VERSION = "1.68.0"
-export const SHUTTLE_VERSION = "0.17.0"
-export const PROTOC_VERSION = "3.19.0"
+export const SHUTTLE_VERSION = "0.18.0"
 
 export const SHUTTLE_TAG = `v${SHUTTLE_VERSION}`
 export const SHUTTLE_DOWNLOAD_URL = `https://github.com/shuttle-hq/shuttle/releases/download/${SHUTTLE_TAG}/`

--- a/index.ts
+++ b/index.ts
@@ -9,7 +9,6 @@ import {
     installRust,
     installShuttle,
     checkInstalled,
-    installProtoc,
 } from "./helpers/check-shuttle"
 import {
     appendUniqueSuffix,
@@ -25,7 +24,6 @@ import {
     SHUTTLE_VERSION,
     SHUTTLE_EXAMPLE_URL,
     SHUTTLE_SAAS_URL,
-    PROTOC_VERSION,
 } from "./helpers/constants"
 
 let projectPath = ""
@@ -109,30 +107,6 @@ async function run(): Promise<void> {
             throw {
                 error: `Rust is required to use shuttle, please refer to https://www.rust-lang.org/tools/install
                 for installation instructions. After installing Rust, please run create-shuttle-app again.`,
-            }
-        }
-    }
-
-    if (
-        !checkInstalled(
-            "protoc",
-            `>=${PROTOC_VERSION} || >=${PROTOC_VERSION.substring(2)}`
-        )
-    ) {
-        const res = await prompts({
-            type: "confirm",
-            name: "installProtoc",
-            initial: true,
-            message: `create-shuttle-app requires a Protoc version greater than or equal to ${PROTOC_VERSION}, 
-            do you wish to install it now?`,
-        })
-
-        if (res.installProtoc) {
-            installProtoc()
-        } else {
-            throw {
-                error: `Protoc is required to use shuttle, please refer to https://docs.shuttle.rs/support/installing-protoc
-                for installation instructions. After installing protoc, please run create-shuttle-app again.`,
             }
         }
     }


### PR DESCRIPTION
This PR bumps the shuttle version, and also removes the protoc installation which is no longer required.