### PR TITLE
chore: v0.1.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "create-shuttle-app",
-    "version": "0.1.20",
+    "version": "0.1.21",
     "bin": {
         "create-shuttle-app": "./dist/index.js"
     },


### PR DESCRIPTION
The environment I published the crate from for 0.1.20 (nix-shell) must have been missing some dependency, so the publish succeeded but the build failed. I saw the same thing when I tried to deploy from windows. This PR is for the 0.1.21 release, which did succeed and is working.