### PR TITLE
chore: bump versions to correspond to v0.24.0 Shuttle

### DIFF
--- a/helpers/constants.ts
+++ b/helpers/constants.ts
@@ -1,6 +1,6 @@
 // The minimum required version of rust.
 export const RUSTC_VERSION = "1.70.0"
-export const SHUTTLE_VERSION = "0.23.0"
+export const SHUTTLE_VERSION = "0.24.0"
 
 export const SHUTTLE_TAG = `v${SHUTTLE_VERSION}`
 export const SHUTTLE_DOWNLOAD_URL = `https://github.com/shuttle-hq/shuttle/releases/download/${SHUTTLE_TAG}/`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "create-shuttle-app",
-    "version": "0.1.24",
+    "version": "0.1.25",
     "bin": {
         "create-shuttle-app": "./dist/index.js"
     },


### PR DESCRIPTION
Bump versions for the v0.24.0 release on Shuttle.