### PR TITLE
chore: v0.1.29

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "create-shuttle-app",
-    "version": "0.1.28",
+    "version": "0.1.29",
     "bin": {
         "create-shuttle-app": "./dist/index.js"
     },


### PR DESCRIPTION
Fix `create-shuttle-app: not found` error from previous release.